### PR TITLE
Update github actions for chalice

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
           echo ::add-path::$HOME/.poetry/bin
       - name: Install
         run: poetry install
+      - name: Generate requirements.txt
+        run: poetry export -f requirements.txt > requirements.txt
       - name: Deploy
         run: poetry run chalice deploy
         env:


### PR DESCRIPTION
Currently, deployed lambda causes `[ERROR] Runtime.ImportModuleError`.
In order to import 3rd party packages with Chalice, it needs "requirements.txt".
( cf. https://chalice.readthedocs.io/en/latest/topics/packaging.html#rd-party-packages )
This PR export requirements.txt from poetry to fix the above error.